### PR TITLE
Removed EntityBase constraint on multiple interfaces and classes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,3 +34,8 @@
 ## 2.2.1
 
 - Bugfix includes with Get and GetAsync
+
+## 2.3.0
+
+- Removed EntityBase constraint on multiple generic interfaces and classes.
+- Added PageNumber, PageLength and TotalPageCount and renamed TotalCount to TotalEntityCount on DataPage class

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.0.0",
+	"version": "2.3.0",
 	"name": "Digipolis.DataAccess",
 	"private": true,
 	"devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Adding the DataAccess Toolbox to a project is as easy as adding it to the projec
 
 ``` json
  "dependencies": {
-    "Digipolis.DataAccess":  "2.2.1",
+    "Digipolis.DataAccess":  "2.3.0",
  }
 ```
 

--- a/src/Digipolis.DataAccess/Paging/DataPage.cs
+++ b/src/Digipolis.DataAccess/Paging/DataPage.cs
@@ -4,7 +4,7 @@ using Digipolis.DataAccess.Entities;
 
 namespace Digipolis.DataAccess.Paging
 {
-    public class DataPage<TEntity> where TEntity : EntityBase
+    public class DataPage<TEntity>
     {
         public IEnumerable<TEntity> Data { get; set; }
         public long TotalEntityCount { get; set; }

--- a/src/Digipolis.DataAccess/Paging/DataPage.cs
+++ b/src/Digipolis.DataAccess/Paging/DataPage.cs
@@ -7,6 +7,16 @@ namespace Digipolis.DataAccess.Paging
     public class DataPage<TEntity> where TEntity : EntityBase
     {
         public IEnumerable<TEntity> Data { get; set; }
-        public long TotalCount { get; set; }
+        public long TotalEntityCount { get; set; }
+
+        public int PageNumber { get; set; }
+        public int PageLength { get; set; }
+
+        public int TotalPageCount {
+            get
+            {
+                return Convert.ToInt32(Math.Ceiling((decimal)TotalEntityCount / PageLength));
+            }
+        }
     }
 }

--- a/src/Digipolis.DataAccess/Paging/DataPager.cs
+++ b/src/Digipolis.DataAccess/Paging/DataPager.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Digipolis.DataAccess.Paging
 {
-    public class DataPager<TEntity> : IDataPager<TEntity> where TEntity : EntityBase
+    public class DataPager<TEntity> : IDataPager<TEntity>
     {
         public DataPager(IUowProvider uowProvider)
         {

--- a/src/Digipolis.DataAccess/Paging/DataPager.cs
+++ b/src/Digipolis.DataAccess/Paging/DataPager.cs
@@ -1,6 +1,7 @@
 ﻿using Digipolis.DataAccess.Entities;
 using Digipolis.DataAccess.Query;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -22,13 +23,10 @@ namespace Digipolis.DataAccess.Paging
                 var repository = uow.GetRepository<TEntity>();
 
                 var startRow = ( pageNumber - 1 ) * pageLength;
-                var page = new DataPage<TEntity>()
-                {
-                    Data = repository.GetPage(startRow, pageLength, includes: includes, orderBy: orderby?.Expression),
-                    TotalCount = repository.Count()
-                };
+                var data = repository.GetPage(startRow, pageLength, includes: includes, orderBy: orderby?.Expression);
+                var totalCount = repository.Count();
 
-                return page;
+                return CreateDataPage(pageNumber, pageLength, data, totalCount);
             }
         }
 
@@ -39,13 +37,10 @@ namespace Digipolis.DataAccess.Paging
                 var repository = uow.GetRepository<TEntity>();
 
                 var startRow = ( pageNumber - 1 ) * pageLength;
-                var page = new DataPage<TEntity>()
-                {
-                    Data = await repository.GetPageAsync(startRow, pageLength, includes: includes, orderBy: orderby?.Expression),
-                    TotalCount = await repository.CountAsync()
-                };
+                var data = await repository.GetPageAsync(startRow, pageLength, includes: includes, orderBy: orderby?.Expression);
+                var totalCount = await repository.CountAsync();
 
-                return page;
+                return CreateDataPage(pageNumber, pageLength, data, totalCount);
             }
         }
 
@@ -56,13 +51,10 @@ namespace Digipolis.DataAccess.Paging
                 var repository = uow.GetRepository<TEntity>();
 
                 var startRow = ( pageNumber - 1 ) * pageLength;
-                var page = new DataPage<TEntity>()
-                {
-                    Data = repository.QueryPage(startRow, pageLength, filter.Expression, includes: includes, orderBy: orderby?.Expression),
-                    TotalCount = repository.Count(filter.Expression)
-                };
+                var data = repository.QueryPage(startRow, pageLength, filter.Expression, includes: includes, orderBy: orderby?.Expression);
+                var totalCount = repository.Count(filter.Expression);
 
-                return page;
+                return CreateDataPage(pageNumber, pageLength, data, totalCount);
             }
         }
 
@@ -73,14 +65,24 @@ namespace Digipolis.DataAccess.Paging
                 var repository = uow.GetRepository<TEntity>();
 
                 var startRow = ( pageNumber - 1 ) * pageLength;
-                var page = new DataPage<TEntity>()
-                {
-                    Data = await repository.QueryPageAsync(startRow, pageLength, filter.Expression, includes: includes, orderBy: orderby?.Expression),
-                    TotalCount = await repository.CountAsync(filter.Expression)
-                };
+                var data = await repository.QueryPageAsync(startRow, pageLength, filter.Expression, includes: includes, orderBy: orderby?.Expression);
+                var totalCount = await repository.CountAsync(filter.Expression);
 
-                return page;
+                return CreateDataPage(pageNumber, pageLength, data, totalCount);
             }
+        }
+
+        private DataPage<TEntity> CreateDataPage(int pageNumber, int pageLength, IEnumerable<TEntity> data, long totalEntityCount)
+        {
+            var page = new DataPage<TEntity>()
+            {
+                Data = data,
+                TotalEntityCount = totalEntityCount,
+                PageLength = pageLength,
+                PageNumber = pageNumber
+            };
+
+            return page;
         }
     }
 }

--- a/src/Digipolis.DataAccess/Paging/IDataPager.cs
+++ b/src/Digipolis.DataAccess/Paging/IDataPager.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Digipolis.DataAccess.Paging
 {
-    public interface IDataPager<TEntity> where TEntity : EntityBase
+    public interface IDataPager<TEntity>
     {
         DataPage<TEntity> Get(int pageNumber, int pageLength, OrderBy<TEntity> orderby = null, Func<IQueryable<TEntity>, IQueryable<TEntity>> includes = null);
         DataPage<TEntity> Query(int pageNumber, int pageLength, Filter<TEntity> filter, OrderBy<TEntity> orderby = null, Func<IQueryable<TEntity>, IQueryable<TEntity>> includes = null);

--- a/src/Digipolis.DataAccess/Query/Filter.cs
+++ b/src/Digipolis.DataAccess/Query/Filter.cs
@@ -4,7 +4,7 @@ using Digipolis.DataAccess.Entities;
 
 namespace Digipolis.DataAccess.Query
 {
-	public class Filter<TEntity> where TEntity : EntityBase
+	public class Filter<TEntity>
 	{
 		public Filter(Expression<Func<TEntity, bool>> expression)
 		{

--- a/src/Digipolis.DataAccess/Query/Includes.cs
+++ b/src/Digipolis.DataAccess/Query/Includes.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace Digipolis.DataAccess.Query
 {
-    public class Includes<TEntity> where TEntity : EntityBase
+    public class Includes<TEntity>
     {
         public Includes(Func<IQueryable<TEntity>, IQueryable<TEntity>> expression)
         {

--- a/src/Digipolis.DataAccess/Query/OrderBy.cs
+++ b/src/Digipolis.DataAccess/Query/OrderBy.cs
@@ -7,7 +7,7 @@ using Digipolis.DataAccess.Entities;
 
 namespace Digipolis.DataAccess.Query
 {
-    public class OrderBy<TEntity> where TEntity : EntityBase
+    public class OrderBy<TEntity>
 	{
 		public OrderBy(Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> expression)
 		{

--- a/src/Digipolis.DataAccess/Repositories/IRepository.cs
+++ b/src/Digipolis.DataAccess/Repositories/IRepository.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Digipolis.DataAccess.Repositories
 {
-    public interface IRepository<TEntity> where TEntity : EntityBase
+    public interface IRepository<TEntity>
 	{
 		IEnumerable<TEntity> GetAll(Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> orderBy = null, Func<IQueryable<TEntity>, IQueryable<TEntity>> includes = null);
 		Task<IEnumerable<TEntity>> GetAllAsync(Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>> orderBy = null, Func<IQueryable<TEntity>, IQueryable<TEntity>> includes = null);

--- a/src/Digipolis.DataAccess/Uow/IUnitOfWorkBase.cs
+++ b/src/Digipolis.DataAccess/Uow/IUnitOfWorkBase.cs
@@ -12,7 +12,7 @@ namespace Digipolis.DataAccess.Uow
         Task<int> SaveChangesAsync();
         Task<int> SaveChangesAsync(CancellationToken cancellationToken);
 
-        IRepository<TEntity> GetRepository<TEntity>() where TEntity : EntityBase;
+        IRepository<TEntity> GetRepository<TEntity>();
         TRepository GetCustomRepository<TRepository>();
     }
 }

--- a/src/Digipolis.DataAccess/Uow/UnitOfWorkBase.cs
+++ b/src/Digipolis.DataAccess/Uow/UnitOfWorkBase.cs
@@ -37,7 +37,7 @@ namespace Digipolis.DataAccess.Uow
             return _context.SaveChangesAsync(cancellationToken);
         }
 
-        public IRepository<TEntity> GetRepository<TEntity>() where TEntity : EntityBase
+        public IRepository<TEntity> GetRepository<TEntity>()
         {
             CheckDisposed();
             var repositoryType = typeof(IRepository<TEntity>);

--- a/src/Digipolis.DataAccess/project.json
+++ b/src/Digipolis.DataAccess/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.1-*",
+  "version": "2.3.0-*",
 
   "dependencies": {
     "Microsoft.EntityFrameworkCore": "1.0.0",

--- a/test/Digipolis.DataAccess.UnitTests/Paging/DataPagerTests.cs
+++ b/test/Digipolis.DataAccess.UnitTests/Paging/DataPagerTests.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Digipolis.DataAccess.UnitTests.Paging
+{
+    public class DataPagerTests
+    {
+        [Fact]
+        public void GetReturnsValidDataPage()
+        {
+            
+        }
+    }
+}

--- a/test/Digipolis.DataAccess.UnitTests/Repositories/GenericEntityRepositoryTests.cs
+++ b/test/Digipolis.DataAccess.UnitTests/Repositories/GenericEntityRepositoryTests.cs
@@ -1,0 +1,226 @@
+﻿using Digipolis.DataAccess.Repositories;
+using Digipolis.DataAccess.UnitTests._TestObjects;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Digipolis.DataAccess.UnitTests.Repositories
+{
+    public class GenericEntityRepositoryTests
+    {
+        private InMemoryContext _context;
+        private IRepository<Foo> _fooRepository;
+
+        public GenericEntityRepositoryTests()
+        {
+            _fooRepository = new GenericEntityRepository<Foo>(null);
+            _context = InMemoryContext.Create();
+            ((IRepositoryInjection<DbContext>)_fooRepository).SetContext(_context);
+        }
+
+        private void AddEntitiesToContext(int count = 10)
+        {
+            // Add entities to context
+            for (var i = 1; i <= count; i++)
+            {
+                var foo = new Foo()
+                {
+                    Id = i
+                };
+
+                _context.Foos.Add(foo);
+            }
+
+            _context.SaveChanges();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(10)]
+        public void GetAllDoesNotReturnNull(int totalEntities)
+        {
+            // Arrange
+            AddEntitiesToContext(totalEntities);
+
+            // Act
+            var result = _fooRepository.GetAll();
+
+            // Assert
+            Assert.NotNull(result);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(10)]
+        public void GetAllReturnsCorrectNumberOfEntities(int totalEntities)
+        {
+            // Arrange
+            AddEntitiesToContext(totalEntities);
+
+            // Act
+            var result = _fooRepository.GetAll();
+
+            // Assert
+            Assert.Equal(totalEntities, result.Count());
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(10)]
+        public void GetAllReturnsAllEntitiesInContext(int totalEntities)
+        {
+            // Arrange
+            AddEntitiesToContext(totalEntities);
+
+            // Act
+            var result = _fooRepository.GetAll();
+
+            // Assert
+            for (int i = 1; i <= totalEntities; i++)
+                Assert.Equal(1, result.Count(x => x.Id == i));
+        }
+
+        [Theory]
+        [InlineData(10)]
+        public void GetAllSortedByIdReturnsAllEntitiesInCorrectOrder(int totalEntities)
+        {
+            // Arrange
+            AddEntitiesToContext(totalEntities);
+
+            // Act
+            var result = _fooRepository.GetAll(x => x.OrderBy(y => y.Id));
+
+            // Assert
+            var i = 0;
+            foreach (var entity in result)
+            {
+                i++;
+                Assert.Equal(i, entity.Id);
+            }
+        }
+
+        [Theory]
+        [InlineData(10)]
+        public void GetAllReverseSortedByIdReturnsAllEntitiesInCorrectOrder(int totalEntities)
+        {
+            // Arrange
+            AddEntitiesToContext(totalEntities);
+
+            // Act
+            var result = _fooRepository.GetAll(x => x.OrderByDescending(y => y.Id));
+
+            // Assert
+            var i = totalEntities;
+            foreach (var entity in result)
+            {
+                Assert.Equal(i, entity.Id);
+                i--;
+            }
+        }
+
+        [Theory]
+        [InlineData(0, 1)]
+        [InlineData(3, 4)]
+        public void GetReturnsNullWhenEntityDoesNotExistInContext(int totalEntities, int id)
+        {
+            // Arrange
+            AddEntitiesToContext(totalEntities);
+
+            // Act
+            var result = _fooRepository.Get(id);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(3, 1)]
+        [InlineData(3, 3)]
+        public void GetDoesNotReturnNullWhenEntityExistsInContext(int totalEntities, int id)
+        {
+            // Arrange
+            AddEntitiesToContext(totalEntities);
+
+            // Act
+            var result = _fooRepository.Get(id);
+
+            // Assert
+            Assert.NotNull(result);
+        }
+
+        [Theory]
+        [InlineData(3, 1)]
+        [InlineData(3, 3)]
+        public void GetReturnsSingleEntityWithProvidedId(int totalEntities, int id)
+        {
+            // Arrange
+            AddEntitiesToContext(totalEntities);
+
+            // Act
+            var result = _fooRepository.Get(id);
+
+            // Assert
+            Assert.Equal(id, result.Id);
+        }
+
+        [Theory]
+        [InlineData(10, 0, 5)]
+        [InlineData(10, 5, 5)]
+        [InlineData(10, 10, 5)]
+        public void GetPageSortedByIdDoesNotReturnNull(int totalEntities, int rowIndex, int pageSize)
+        {
+            // Arrange
+            AddEntitiesToContext(totalEntities);
+
+            // Act
+            var result = _fooRepository.GetPage(rowIndex, pageSize, x => x.OrderBy(y => y.Id));
+
+            // Assert
+            Assert.NotNull(result);
+        }
+
+        [Theory]
+        [InlineData(10, 0, 5)]
+        [InlineData(10, 5, 5)]
+        [InlineData(10, 10, 5)]
+        [InlineData(8, 5, 5)]
+        public void GetPageSortedByIdReturnsCorrectNumberOfEntities(int totalEntities, int rowIndex, int pageSize)
+        {
+            // Arrange
+            AddEntitiesToContext(totalEntities);
+            var minId = rowIndex + 1;
+            var maxId = Math.Min(totalEntities, minId + pageSize - 1);
+            var expectedNumberOfEntities = Math.Max(0, maxId - minId + 1);
+
+            // Act
+            var result = _fooRepository.GetPage(rowIndex, pageSize, x => x.OrderBy(y => y.Id));
+
+            // Assert
+            Assert.Equal(expectedNumberOfEntities, result.Count());
+        }
+
+        [Theory]
+        [InlineData(10, 0, 5)]
+        [InlineData(10, 5, 5)]
+        [InlineData(10, 10, 5)]
+        [InlineData(8, 5, 5)]
+        public void GetPageSortedByIdReturnsEntitiesWithCorrectIds(int totalEntities, int rowIndex, int pageSize)
+        {
+            // Arrange
+            AddEntitiesToContext(totalEntities);
+
+            var minId = rowIndex + 1;
+            var maxId = Math.Min(totalEntities, minId + pageSize - 1);
+
+            // Act
+            var result = _fooRepository.GetPage(rowIndex, pageSize, x => x.OrderBy(y => y.Id));
+
+            // Assert
+            for (int i = minId; i <= maxId; i++)
+                Assert.Equal(1, result.Count(x => x.Id == i));
+        }
+    }
+}

--- a/test/Digipolis.DataAccess.UnitTests/_TestObjects/Foo.cs
+++ b/test/Digipolis.DataAccess.UnitTests/_TestObjects/Foo.cs
@@ -1,0 +1,12 @@
+﻿using Digipolis.DataAccess.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Digipolis.DataAccess.UnitTests._TestObjects
+{
+    public class Foo : EntityBase
+    {
+    }
+}

--- a/test/Digipolis.DataAccess.UnitTests/_TestObjects/InMemoryContext.cs
+++ b/test/Digipolis.DataAccess.UnitTests/_TestObjects/InMemoryContext.cs
@@ -1,0 +1,37 @@
+﻿using Digipolis.DataAccess.Context;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Digipolis.DataAccess.UnitTests._TestObjects
+{
+    public class InMemoryContext : EntityContextBase<InMemoryContext>
+    {
+        public InMemoryContext(DbContextOptions<InMemoryContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Foo> Foos { get; set; }
+
+        public static InMemoryContext Create()
+        {
+            // Create a fresh service provider, and therefore a fresh 
+            // InMemory database instance.
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkInMemoryDatabase()
+                .BuildServiceProvider();
+
+            // Create a new options instance telling the context to use an
+            // InMemory database and the new service provider.
+            var builder = new DbContextOptionsBuilder<InMemoryContext>();
+            builder.UseInMemoryDatabase()
+                   .UseInternalServiceProvider(serviceProvider);
+
+            return new InMemoryContext(builder.Options);
+        }
+    }
+}

--- a/test/Digipolis.DataAccess.UnitTests/project.json
+++ b/test/Digipolis.DataAccess.UnitTests/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "1.0.0-*",
   "description": "Unit tests for the DataAccess toolbox",
   "authors": [ "digipolis.be" ],
@@ -7,7 +7,8 @@
     "Digipolis.DataAccess": "*",
     "NETStandard.Library": "1.6.0",
     "xunit": "2.2.0-beta2-build3300",
-    "dotnet-test-xunit": "2.2.0-preview2-build1029"
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
+    "Microsoft.EntityFrameworkCore.InMemory": "1.0.0"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
Only the constraints on the EntityRepositoryBase and GenericEntityRepository remain to be able to filter on EntityBase.Id property for the Get operation.